### PR TITLE
Fix ambiguity in attribute names

### DIFF
--- a/src/server/models/dao/sequelize.coffee
+++ b/src/server/models/dao/sequelize.coffee
@@ -166,7 +166,8 @@ class Salad.DAO.Sequelize extends Salad.DAO.Base
       params.order = order
 
     if options.contains.length > 0
-      attribs = ("'#{contains.value}' = ANY(\"#{contains.field}\")" for contains in options.contains)
+      tableName = @modelClass.daoInstance.daoModelInstance.tableName
+      attribs = ("'#{contains.value}' = ANY(\"#{tableName}\".\"#{contains.field}\")" for contains in options.contains)
 
       if params.where
         for key, val of params.where

--- a/test/app/models/server/child.coffee
+++ b/test/app/models/server/child.coffee
@@ -1,7 +1,8 @@
 require "./parent"
 
 App.SequelizeChild = App.sequelize.define "Child",
-  {title: Sequelize.STRING}
+  {title: Sequelize.STRING,
+  otherTitle: Sequelize.ARRAY(Sequelize.STRING)}
   {tableName: "children"}
 
 App.SequelizeParent.hasMany App.SequelizeChild, foreignKey: "parentId"
@@ -15,6 +16,7 @@ class App.Child extends Salad.Model
 
   @attribute "id"
   @attribute "title"
+  @attribute "otherTitle"
   @attribute "createdAt"
   @attribute "updatedAt"
 

--- a/test/app/models/server/parent.coffee
+++ b/test/app/models/server/parent.coffee
@@ -1,5 +1,6 @@
 App.SequelizeParent = App.sequelize.define "Parent",
   title: Sequelize.STRING
+  otherTitle: Sequelize.ARRAY(Sequelize.STRING)
 
 class App.Parent extends Salad.Model
   @dao
@@ -8,6 +9,7 @@ class App.Parent extends Salad.Model
 
   @attribute "id"
   @attribute "title"
+  @attribute "otherTitle"
   @attribute "createdAt"
   @attribute "updatedAt"
 

--- a/test/models/modelTest.coffee
+++ b/test/models/modelTest.coffee
@@ -561,6 +561,14 @@ describe "Salad.Model", ->
               resources.length.should.equal 1
               done()
 
+      it "should prohibit ambiguity", (done) ->
+        App.Parent.create title: "Parent", otherTitle: ["Peter", "Alex"], (err, parent) =>
+          parent.getChildren().create title: "Child", otherTitle: ["Hans", "Max"], (err, child) =>
+            App.Parent.includes([App.Child]).contains("otherTitle", "Peter").all (err, resources) =>
+              resources.length.should.equal 1
+              done()
+
+
       it "allows camelCase in field title", (done) ->
         App.Shop.create anotherTitle: ["A", "B"], (err, resource) ->
           resource.set "anotherTitle", ["A", "B", "C"]


### PR DESCRIPTION
When includes and contains is used and both models have a attribute of
type Sequelize.ARRAY no error is thrown
